### PR TITLE
j5int Fork of material-ui with a few fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-ui-build",
   "private": true,
   "author": "Call-em-all Engineering Team",
-  "version": "0.16.4-j51",
+  "version": "0.16.4-j5int.1",
   "description": "React Components that Implement Google's Material Design.",
   "main": "./src/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-ui-build",
   "private": true,
   "author": "Call-em-all Engineering Team",
-  "version": "0.16.4",
+  "version": "0.16.4-j51",
   "description": "React Components that Implement Google's Material Design.",
   "main": "./src/index.js",
   "keywords": [

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -223,7 +223,7 @@ class DialogInline extends Component {
     if (autoDetectWindowHeight || autoScrollBodyContent) {
       const styles = getStyles(this.props, this.context);
       styles.body = Object.assign(styles.body, bodyStyle);
-      let maxDialogContentHeight = clientHeight - 2 * 64;
+      let maxDialogContentHeight = (clientHeight - paddingTop) - 2 * 64;
 
       if (title) maxDialogContentHeight -= dialogContent.previousSibling.offsetHeight;
 

--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -64,10 +64,10 @@ class RenderToLayer extends Component {
     if (this.props.useLayerForClickAway) {
       this.layer.style.position = 'relative';
       this.layer.removeEventListener('touchstart', this.onClickAway);
-      this.layer.removeEventListener('click', this.onClickAway);
+      this.layer.removeEventListener('mousedown', this.onClickAway);
     } else {
       window.removeEventListener('touchstart', this.onClickAway);
-      window.removeEventListener('click', this.onClickAway);
+      window.removeEventListener('mousedown', this.onClickAway);
     }
 
     unmountComponentAtNode(this.layer);
@@ -94,7 +94,7 @@ class RenderToLayer extends Component {
 
         if (this.props.useLayerForClickAway) {
           this.layer.addEventListener('touchstart', this.onClickAway);
-          this.layer.addEventListener('click', this.onClickAway);
+          this.layer.addEventListener('mousedown', this.onClickAway);
           this.layer.style.position = 'fixed';
           this.layer.style.top = 0;
           this.layer.style.bottom = 0;
@@ -104,7 +104,7 @@ class RenderToLayer extends Component {
         } else {
           setTimeout(() => {
             window.addEventListener('touchstart', this.onClickAway);
-            window.addEventListener('click', this.onClickAway);
+            window.addEventListener('mousedown', this.onClickAway);
           }, 0);
         }
       }


### PR DESCRIPTION
The `j5int` fork of material-ui with a few minor fixes:

* For the `RenderToLayer` internal component, listen for `mousedown` events for triggering the click away so that right-click events also trigger the handler.
* When positioning the `Dialog` component, take the top padding into account when setting the max height of the contents to ensure that the bottom actions bar does not get rendered out of view.
