### PR TITLE
[TimePicker] TimePicker can use different formats for input and display

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -40,6 +40,10 @@ class TimePicker extends Component {
      */
     format: PropTypes.oneOf(['ampm', '24hr']),
     /**
+     * Tells the component to display the text in `ampm` (12hr) format or `24hr` format.
+     */
+    displayFormat: PropTypes.oneOf(['ampm', '24hr']),
+    /**
      * Override the label of the 'OK' button.
      */
     okLabel: PropTypes.node,
@@ -182,6 +186,7 @@ class TimePicker extends Component {
       dialogBodyStyle,
       dialogStyle,
       format,
+      displayFormat,
       okLabel,
       onFocus, // eslint-disable-line no-unused-vars
       onTouchTap, // eslint-disable-line no-unused-vars
@@ -202,7 +207,7 @@ class TimePicker extends Component {
           {...other}
           style={textFieldStyle}
           ref="input"
-          value={time === emptyTime ? null : formatTime(time, format, pedantic)}
+          value={time === emptyTime ? null : formatTime(time, displayFormat, pedantic)}
           onFocus={this.handleFocusInput}
           onTouchTap={this.handleTouchTapInput}
         />


### PR DESCRIPTION
The 24-hour date input component is easier to use on small screens, but the required display format once chosen was ampm. These had to be the same. This change unlinks them and provides an extra prop for the display format.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

